### PR TITLE
Add commit hook with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v3.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: 'https://github.com/markdownlint/markdownlint'
+    rev: v0.11.0
+    hooks:
+      - id: markdownlint


### PR DESCRIPTION
This file is used by pre-commit to perform some lints and checks before allow the contributor to commit their code.

Checks performed:

1. Trailing White spaces to preserve the 2 spaces tabs
2. End of line fixer
3. Markdown Linter

Im looking for a spell checker that works with Aspell and pre-commit but I think I have to make it myself for this repo.

To test this hook please follow **Environment setting and test** in #8 